### PR TITLE
Feature properties without content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/tmp
 test/version_tmp
 tmp
 spec/environment.rb
+.ruby-version

--- a/carrierwave-azure_rm.gemspec
+++ b/carrierwave-azure_rm.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave'
-  gem.add_dependency 'azure-storage', '~> 0.12.0'
+  gem.add_dependency 'azure-storage', '~> 0.12.0.preview'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3'

--- a/carrierwave-azure_rm.gemspec
+++ b/carrierwave-azure_rm.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'carrierwave'
-  gem.add_dependency 'azure-storage', '~> 0.10.2.preview'
+  gem.add_dependency 'azure-storage', '~> 0.12.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3'

--- a/lib/carrierwave/storage/azure_rm.rb
+++ b/lib/carrierwave/storage/azure_rm.rb
@@ -107,13 +107,20 @@ module CarrierWave
         private
 
         def blob
-          load_content if @blob.nil?
+          load_blob if @blob.nil?
           @blob
         end
 
         def content
           load_content if @content.nil?
           @content
+        end
+
+        def load_blob
+          @blob = begin
+            @connection.get_blob_properties @uploader.azure_container, @path
+          rescue ::Azure::Core::Http::HTTPError
+          end
         end
 
         def load_content


### PR DESCRIPTION
This change allows to access content_type and size of file without retrieving the complete file from azure, instead it just loads the blob properties for this purpose and skips content loading.

So file info can be accessed without calling `#retrieve!`