### PR TITLE
Feature/private blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ return signed urls on the files. Enable auto_sign in the configuration:
 
 ```ruby
 config.auto_sign_urls = true
+config.token_expire_after = 3600 # optional - Set the expire time of the url to 3600 seconds. Default is 1800 seconds 
 ```
 
 If you wish a newly created container to be initialized with a specific access_level you can set the following in

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you wish a newly created container to be initialized with a specific access_l
 your config:
 
 ```ruby
-config.public_access_level = 'priavte' # optional - possible values are blob, private, container
+config.public_access_level = 'private' # optional - possible values are blob, private, container
 ```
 
 This config is only required if your container does not exist and you want it to be configured automatically.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ end
 ```
 
 ## Private blobs
-If your container access policy is set to private, carrierwave-azure_rm will automatically
-returned signed urls on the files.
+If your container access policy is set to private, carrierwave-azure_rm can automatically
+return signed urls on the files. Enable auto_sign in the configuration:
+
+```ruby
+config.auto_sign_urls = true
+```
 
 If you wish a newly created container to be initialized with a specific access_level you can set the following in
 your config:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ class ExampleUploader < CarrierWave::Uploader::Base
 end
 ```
 
+## Private blobs
+If your container access policy is set to private, carrierwave-azure_rm will automatically
+returned signed urls on the files.
+
+If you wish a newly created container to be initialized with a specific access_level you can set the following in
+your config:
+
+```ruby
+config.public_access_level = 'priavte' # optional - possible values are blob, private, container
+```
+
+This config is only required if your container does not exist and you want it to be configured automatically.
+
+[Manage access to blobs](https://docs.microsoft.com/en-us/azure/storage/storage-manage-access-to-resources) 
+
 ## Issues
 If you have any problems with or questions about this image, please contact me through a [GitHub issue](https://github.com/nooulaif/carrierwave-azure_rm/issues).
 

--- a/lib/carrierwave-azure_rm.rb
+++ b/lib/carrierwave-azure_rm.rb
@@ -8,6 +8,7 @@ class CarrierWave::Uploader::Base
   add_config :azure_storage_blob_host
   add_config :azure_container
   add_config :public_access_level
+  add_config :auto_sign_urls
 
   configure do |config|
     config.public_access_level = 'blob'

--- a/lib/carrierwave-azure_rm.rb
+++ b/lib/carrierwave-azure_rm.rb
@@ -7,8 +7,10 @@ class CarrierWave::Uploader::Base
   add_config :azure_storage_access_key
   add_config :azure_storage_blob_host
   add_config :azure_container
+  add_config :public_access_level
 
   configure do |config|
+    config.public_access_level = 'blob'
     config.storage_engines[:azure_rm] = 'CarrierWave::Storage::AzureRM'
   end
 end

--- a/lib/carrierwave-azure_rm.rb
+++ b/lib/carrierwave-azure_rm.rb
@@ -9,9 +9,11 @@ class CarrierWave::Uploader::Base
   add_config :azure_container
   add_config :public_access_level
   add_config :auto_sign_urls
+  add_config :token_expire_after
 
   configure do |config|
     config.public_access_level = 'blob'
+    config.token_expire_after = 1800
     config.storage_engines[:azure_rm] = 'CarrierWave::Storage::AzureRM'
   end
 end

--- a/lib/carrierwave/storage/azure_rm.rb
+++ b/lib/carrierwave/storage/azure_rm.rb
@@ -79,7 +79,10 @@ module CarrierWave
           else
             uri = @connection.generate_uri(path)
             if sign_url?(options)
-              @signer.signed_uri(uri, false, { permissions: 'r' }).to_s
+              @signer.signed_uri(uri, false, { permissions: 'r',
+                                               resource: 'b',
+                                               start: 1.minute.ago.utc.iso8601,
+                                               expiry: expires_at}).to_s
             else
               uri.to_s
             end
@@ -130,6 +133,11 @@ module CarrierWave
           lvl = @uploader.public_access_level
           raise "Invalid Access level #{lvl}." unless %w(private blob container).include? lvl
           lvl == 'private' ? {} : { :public_access_level => lvl }
+        end
+
+        def expires_at
+          expiry = Time.now + @uploader.token_expire_after
+          expiry.utc.iso8601
         end
 
         def sign_url?(options)

--- a/lib/carrierwave/storage/azure_rm.rb
+++ b/lib/carrierwave/storage/azure_rm.rb
@@ -40,8 +40,14 @@ module CarrierWave
 
         def ensure_container_exists(name)
           unless @connection.list_containers.any? { |c| c.name == name }
-            @connection.create_container(name, public_access_level: @uploader.public_access_level)
+            @connection.create_container(name, access_level_option)
           end
+        end
+
+        def access_level_option
+          lvl = @uploader.public_access_level
+          raise "Invalid Access level #{lvl}." unless %w(private blob container).include? lvl
+          lvl == 'private' ? {} : { :public_access_level => lvl }
         end
 
         def resolve_access_level

--- a/spec/carrierwave-azure_spec.rb
+++ b/spec/carrierwave-azure_spec.rb
@@ -11,4 +11,8 @@ describe CarrierWave::Uploader::Base do
     is_expected.to respond_to(:azure_storage_blob_host)
     is_expected.to respond_to(:azure_container)
   end
+
+  it 'should have public_access_level blob by default' do
+    expect(described_class.public_access_level).to eq 'blob'
+  end
 end

--- a/spec/carrierwave-azure_spec.rb
+++ b/spec/carrierwave-azure_spec.rb
@@ -10,6 +10,7 @@ describe CarrierWave::Uploader::Base do
     is_expected.to respond_to(:azure_storage_access_key)
     is_expected.to respond_to(:azure_storage_blob_host)
     is_expected.to respond_to(:azure_container)
+    is_expected.to respond_to(:auto_sign_urls)
   end
 
   it 'should have public_access_level blob by default' do

--- a/spec/carrierwave-azure_spec.rb
+++ b/spec/carrierwave-azure_spec.rb
@@ -11,9 +11,14 @@ describe CarrierWave::Uploader::Base do
     is_expected.to respond_to(:azure_storage_blob_host)
     is_expected.to respond_to(:azure_container)
     is_expected.to respond_to(:auto_sign_urls)
+    is_expected.to respond_to(:token_expire_after)
   end
 
   it 'should have public_access_level blob by default' do
     expect(described_class.public_access_level).to eq 'blob'
+  end
+
+  it 'should have set token_expire_after to 30 minutes' do
+    expect(described_class.token_expire_after).to eq 30*60
   end
 end

--- a/spec/carrierwave/storage/azure_file_spec.rb
+++ b/spec/carrierwave/storage/azure_file_spec.rb
@@ -13,11 +13,17 @@ describe CarrierWave::Storage::AzureRM::File do
       allow(uploader).to receive(:azure_container).and_return('test')
     end
 
-    subject { CarrierWave::Storage::AzureRM::File.new(uploader, storage.connection, 'dummy.txt').url }
+    subject { CarrierWave::Storage::AzureRM::File.new(uploader, storage.connection, 'dummy.txt', storage.signer).url }
 
     context 'with storage_blob_host' do
       before do
+        # This must be first!
         allow(uploader).to receive(:azure_storage_blob_host).and_return('http://example.com')
+
+        # automatic resolving won't work for non existent url
+        struct = Struct.new('Container', :public_access_level).new
+        struct.public_access_level = 'blob'
+        allow(storage.connection).to receive(:get_container_acl).and_return(struct)
       end
 
       it 'should return on asset_host' do
@@ -41,7 +47,7 @@ describe CarrierWave::Storage::AzureRM::File do
       allow(storage.connection).to receive(:get_blob).and_return(nil)
     end
 
-    subject { CarrierWave::Storage::AzureRM::File.new(uploader, storage.connection, 'dummy.txt').exists? }
+    subject { CarrierWave::Storage::AzureRM::File.new(uploader, storage.connection, 'dummy.txt', storage.signer).exists? }
 
     context 'when blob file does not exist' do
       it 'should return false' do

--- a/spec/carrierwave/storage/azure_spec.rb
+++ b/spec/carrierwave/storage/azure_spec.rb
@@ -68,11 +68,35 @@ describe CarrierWave::Storage::AzureRM do
     it_should_behave_like 'an expected return value' do
       subject { stored_file }
     end
+
+    context 'private container' do
+      before {
+        allow(uploader).to receive(:public_access_level).and_return('private')
+        allow(uploader).to receive(:azure_container).and_return('carrerwaveprivate')
+        allow(uploader).to receive(:auto_sign_urls).and_return(true)
+      }
+
+      it_should_behave_like 'an expected return value' do
+        subject { stored_file }
+      end
+    end
   end
 
   describe '#retrieve' do
     it_should_behave_like 'an expected return value' do
       subject { retrieved_file }
+    end
+
+    context 'private container' do
+      before {
+        allow(uploader).to receive(:public_access_level).and_return('private')
+        allow(uploader).to receive(:azure_container).and_return('carrerwaveprivate')
+        allow(uploader).to receive(:auto_sign_urls).and_return(true)
+      }
+
+      it_should_behave_like 'an expected return value' do
+        subject { retrieved_file }
+      end
     end
   end
 end


### PR DESCRIPTION
This feature allows carrierwave-azure_rm to automatically sign the returned urls if the accesspolicy of the blobs is set to private. This makes it easy to handle private files on azure