### PR TITLE
Properly namespace Azure::Storage

### DIFF
--- a/lib/carrierwave/storage/azure_rm.rb
+++ b/lib/carrierwave/storage/azure_rm.rb
@@ -18,7 +18,7 @@ module CarrierWave
           %i(storage_account_name storage_access_key storage_blob_host).each do |key|
             ::Azure::Storage.send("#{key}=", uploader.send("azure_#{key}"))
           end
-          Azure::Storage::Blob::BlobService.new
+          ::Azure::Storage::Blob::BlobService.new
         end
       end
 


### PR DESCRIPTION
It was not loading `Azure::Storage::Blob::BlobService` properly from the `azure-storage` gem. Instead it was trying to load `CarrierWave::Storage::AzureRM::Azure::Storage::Blob::BlobService`.